### PR TITLE
fix Channel.recv()

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,12 @@ module.exports = class Channel {
     // unblock pending sends
     if (this.sends.length) {
       const send = this.sends.shift()
-      if (this.closed) return send.promise.reject(new Error('send on closed channel'))
+
+      if (this.closed) {
+        send.promise.reject(new Error('send on closed channel'))
+        return Promise.resolve()
+      }
+
       send.promise.resolve()
       return Promise.resolve(send.value)
     }

--- a/test/index.js
+++ b/test/index.js
@@ -41,6 +41,14 @@ describe('general', function() {
   it('should recv() undefined after close()', function() {
     const ch = new Channel
 
+    co(function *(){
+      try {
+        yield ch.send('hello')
+      } catch (err) {
+        err.message.should.equal('send on closed channel')
+      }
+    })
+
     return co(function *(){
       ch.close()
 


### PR DESCRIPTION
`deferred.reject()` returns `undefined`.
`channel.close()` executes when there is value in `channel.sends`.
Following error occurs.

```
TypeError: You may only yield a function, promise, generator, array, or
object, but the following object was passed: "undefined"
```
